### PR TITLE
[TG-21005, TG-21006] Action release preparation

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -30,26 +30,6 @@ jobs:
           #
           token: ${{ secrets.DIFFBLUE_ACCESS_TOKEN }}
 
-      # Diffblue Cover requires the project to be built so that
-      # the class files can be analysed and tests created.
-
-      # This job configures Java so that the project can be built.
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: '8'
-          distribution: 'zulu'
-
-      # This job runs a Maven command to build the project.
-      - name: Maven Install
-        working-directory: ./test
-        run: mvn --batch-mode install
-
-      # # This job runs a Gradle command to build the project.
-      # - name: Gradle Build
-      #   working-directory: ./test
-      #   run: ./gradlew --console plain build
-
       # Run Diffblue Cover
       - name: Diffblue Cover
         uses: ./ # the latest version from the current repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Default to using the latest version of Diffblue Cover on JDK17
 # Additional images are available for specific Diffblue Cover
 # versions and JDK versions.
-FROM diffblue/cover-cli:latest-jdk17
+FROM diffblue/internal-cover-cli:nightly-jdk17
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -52,24 +52,6 @@ jobs:
           #
           token: ${{ secrets.DIFFBLUE_ACCESS_TOKEN }}
 
-      # Diffblue Cover requires the project to be built so that
-      # the class files can be analysed and tests created.
-
-      # This job configures Java so that the project can be built.
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'zulu'
-
-      # This job runs a Maven command to build the project.
-      - name: Maven Install
-        run: mvn --batch-mode install
-
-      # # This job runs a Gradle command to build the project.
-      # - name: Gradle Build
-      #   run: ./gradlew --console plain build
-
       # Run Diffblue Cover
       - name: Diffblue Cover
         uses: diffblue/cover-github-action@main
@@ -94,6 +76,7 @@ jobs:
           # args: >-
           #   ci
           #   activate
+          #   build
           #   validate
           #   create
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,7 @@ inputs:
     default: >-
       ci
       activate
+      build
       validate
       create
   working-directory:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,9 +11,5 @@ git fetch --all --deepen=5
 # Reset the image-specific environment
 export $(cat /.env | xargs)
 
-# Just change directory here because it's easier than
-# correctly adding --working-directory to each command
-cd "${DIFFBLUE_WORKING_DIRECTORY}"
-
 # The command to run. Should ci and activate be mandatory?
 /opt/cover/dcover ${INPUT_ARGS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,9 +5,6 @@ set -ex
 # Mark the workspace as safe
 /usr/bin/git config --system --add safe.directory `pwd`
 
-# Hmmmmm... fetch the next few refs just to get started
-git fetch --all --deepen=5
-
 # Reset the image-specific environment
 export $(cat /.env | xargs)
 

--- a/jdk11/Dockerfile
+++ b/jdk11/Dockerfile
@@ -1,7 +1,7 @@
 # Default to using the latest version of Diffblue Cover on JDK11
 # Additional images are available for specific Diffblue Cover
 # versions and JDK versions.
-FROM diffblue/cover-cli:latest-jdk11
+FROM diffblue/internal-cover-cli:nightly-jdk11
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/jdk11/action.yml
+++ b/jdk11/action.yml
@@ -27,6 +27,7 @@ inputs:
     default: >-
       ci
       activate
+      build
       validate
       create
   working-directory:

--- a/jdk11/entrypoint.sh
+++ b/jdk11/entrypoint.sh
@@ -11,9 +11,5 @@ git fetch --all --deepen=5
 # Reset the image-specific environment
 export $(cat /.env | xargs)
 
-# Just change directory here because it's easier than
-# correctly adding --working-directory to each command
-cd "${DIFFBLUE_WORKING_DIRECTORY}"
-
 # The command to run. Should ci and activate be mandatory?
 /opt/cover/dcover ${INPUT_ARGS}

--- a/jdk11/entrypoint.sh
+++ b/jdk11/entrypoint.sh
@@ -5,9 +5,6 @@ set -ex
 # Mark the workspace as safe
 /usr/bin/git config --system --add safe.directory `pwd`
 
-# Hmmmmm... fetch the next few refs just to get started
-git fetch --all --deepen=5
-
 # Reset the image-specific environment
 export $(cat /.env | xargs)
 

--- a/jdk17/Dockerfile
+++ b/jdk17/Dockerfile
@@ -1,7 +1,7 @@
 # Default to using the latest version of Diffblue Cover on JDK17
 # Additional images are available for specific Diffblue Cover
 # versions and JDK versions.
-FROM diffblue/cover-cli:latest-jdk17
+FROM diffblue/internal-cover-cli:nightly-jdk17
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/jdk17/action.yml
+++ b/jdk17/action.yml
@@ -27,6 +27,7 @@ inputs:
     default: >-
       ci
       activate
+      build
       validate
       create
   working-directory:

--- a/jdk17/entrypoint.sh
+++ b/jdk17/entrypoint.sh
@@ -11,9 +11,5 @@ git fetch --all --deepen=5
 # Reset the image-specific environment
 export $(cat /.env | xargs)
 
-# Just change directory here because it's easier than
-# correctly adding --working-directory to each command
-cd "${DIFFBLUE_WORKING_DIRECTORY}"
-
 # The command to run. Should ci and activate be mandatory?
 /opt/cover/dcover ${INPUT_ARGS}

--- a/jdk17/entrypoint.sh
+++ b/jdk17/entrypoint.sh
@@ -5,9 +5,6 @@ set -ex
 # Mark the workspace as safe
 /usr/bin/git config --system --add safe.directory `pwd`
 
-# Hmmmmm... fetch the next few refs just to get started
-git fetch --all --deepen=5
-
 # Reset the image-specific environment
 export $(cat /.env | xargs)
 

--- a/jdk21/Dockerfile
+++ b/jdk21/Dockerfile
@@ -1,7 +1,7 @@
 # Default to using the latest version of Diffblue Cover on JDK21
 # Additional images are available for specific Diffblue Cover
 # versions and JDK versions.
-FROM diffblue/cover-cli:latest-jdk21
+FROM diffblue/internal-cover-cli:nightly-jdk21
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/jdk21/action.yml
+++ b/jdk21/action.yml
@@ -27,6 +27,7 @@ inputs:
     default: >-
       ci
       activate
+      build
       validate
       create
   working-directory:

--- a/jdk21/entrypoint.sh
+++ b/jdk21/entrypoint.sh
@@ -11,9 +11,5 @@ git fetch --all --deepen=5
 # Reset the image-specific environment
 export $(cat /.env | xargs)
 
-# Just change directory here because it's easier than
-# correctly adding --working-directory to each command
-cd "${DIFFBLUE_WORKING_DIRECTORY}"
-
 # The command to run. Should ci and activate be mandatory?
 /opt/cover/dcover ${INPUT_ARGS}

--- a/jdk21/entrypoint.sh
+++ b/jdk21/entrypoint.sh
@@ -5,9 +5,6 @@ set -ex
 # Mark the workspace as safe
 /usr/bin/git config --system --add safe.directory `pwd`
 
-# Hmmmmm... fetch the next few refs just to get started
-git fetch --all --deepen=5
-
 # Reset the image-specific environment
 export $(cat /.env | xargs)
 

--- a/jdk8/Dockerfile
+++ b/jdk8/Dockerfile
@@ -1,7 +1,7 @@
 # Default to using the latest version of Diffblue Cover on JDK8
 # Additional images are available for specific Diffblue Cover
 # versions and JDK versions.
-FROM diffblue/cover-cli:latest-jdk8
+FROM diffblue/internal-cover-cli:nightly-jdk8
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/jdk8/action.yml
+++ b/jdk8/action.yml
@@ -27,6 +27,7 @@ inputs:
     default: >-
       ci
       activate
+      build
       validate
       create
   working-directory:

--- a/jdk8/entrypoint.sh
+++ b/jdk8/entrypoint.sh
@@ -11,9 +11,5 @@ git fetch --all --deepen=5
 # Reset the image-specific environment
 export $(cat /.env | xargs)
 
-# Just change directory here because it's easier than
-# correctly adding --working-directory to each command
-cd "${DIFFBLUE_WORKING_DIRECTORY}"
-
 # The command to run. Should ci and activate be mandatory?
 /opt/cover/dcover ${INPUT_ARGS}

--- a/jdk8/entrypoint.sh
+++ b/jdk8/entrypoint.sh
@@ -5,9 +5,6 @@ set -ex
 # Mark the workspace as safe
 /usr/bin/git config --system --add safe.directory `pwd`
 
-# Hmmmmm... fetch the next few refs just to get started
-git fetch --all --deepen=5
-
 # Reset the image-specific environment
 export $(cat /.env | xargs)
 


### PR DESCRIPTION
# TG-21005, TG-21006

- Action update to use internal nightly docker images (for now)
  - Need to switch back to latest-released when releasing.
- Action now trusts that:
  - Docker image will process `DIFFBLUE_WORKING_DIRECTORY` itself
  - Docker image will build the project via `dcover build` by default
  - Docker image will handle merge commit checkouts