### PR TITLE
README example always uploads logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ jobs:
 
       # Collect Diffblue Cover log files
       - name: Diffblue Artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: logs


### PR DESCRIPTION
Update the exmaple in the README to ensure logs are always uploaded even in failure.