### PR TITLE
style fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ jobs:
           # working-directory: path/to/project
 
           # The Diffblue Cover commands and options to use.
-          # args: >-
-          #   ci
-          #   activate
-          #   build
-          #   validate
-          #   create
+          #args: >-
+          #  ci
+          #  activate
+          #  build
+          #  validate
+          #  create
 
       # Collect Diffblue Cover log files
       - name: Diffblue Artifacts


### PR DESCRIPTION
ATM, when I uncomment args from yml file, i got syntax error of missing a space. 

<img width="631" alt="Screenshot 2024-03-20 at 16 53 57" src="https://github.com/diffblue/cover-github-action/assets/42343551/8be08d6d-daa8-4d6b-b1e3-9c5ae3c3a160">

Adding an extra space fixes the issue