### PR TITLE
action.yml descriptions must be <125 characters long

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check - Description Length
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq eval --exit-status '.description | length < 125' action.yml
+
       - name: Build
         run: |
           # Rebuild per-JDK actions based on the base content

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,7 @@
 name: Diffblue Cover
 description:
-  Runs Diffblue Cover to automatically write and maintain Java unit tests.
-  Variations of the action are available using various supported JDK versions.
-  This variation uses JDK17.
+  Runs Diffblue Cover directly in your workflow to autonomously write
+  Java unit tests on your pull requests.
 author: Diffblue
 branding:
   icon: check-circle

--- a/jdk11/action.yml
+++ b/jdk11/action.yml
@@ -1,8 +1,7 @@
 name: Diffblue Cover
 description:
-  Runs Diffblue Cover to automatically write and maintain Java unit tests.
-  Variations of the action are available using various supported JDK versions.
-  This variation uses JDK11.
+  Runs Diffblue Cover directly in your workflow to autonomously write
+  Java unit tests on your pull requests.
 author: Diffblue
 branding:
   icon: check-circle

--- a/jdk17/action.yml
+++ b/jdk17/action.yml
@@ -1,8 +1,7 @@
 name: Diffblue Cover
 description:
-  Runs Diffblue Cover to automatically write and maintain Java unit tests.
-  Variations of the action are available using various supported JDK versions.
-  This variation uses JDK17.
+  Runs Diffblue Cover directly in your workflow to autonomously write
+  Java unit tests on your pull requests.
 author: Diffblue
 branding:
   icon: check-circle

--- a/jdk21/action.yml
+++ b/jdk21/action.yml
@@ -1,8 +1,7 @@
 name: Diffblue Cover
 description:
-  Runs Diffblue Cover to automatically write and maintain Java unit tests.
-  Variations of the action are available using various supported JDK versions.
-  This variation uses JDK21.
+  Runs Diffblue Cover directly in your workflow to autonomously write
+  Java unit tests on your pull requests.
 author: Diffblue
 branding:
   icon: check-circle

--- a/jdk8/action.yml
+++ b/jdk8/action.yml
@@ -1,8 +1,7 @@
 name: Diffblue Cover
 description:
-  Runs Diffblue Cover to automatically write and maintain Java unit tests.
-  Variations of the action are available using various supported JDK versions.
-  This variation uses JDK8.
+  Runs Diffblue Cover directly in your workflow to autonomously write
+  Java unit tests on your pull requests.
 author: Diffblue
 branding:
   icon: check-circle


### PR DESCRIPTION
While discussing release process with Thomas P we learned that `action.yml` description must be <125 characters:
![image](https://github.com/diffblue/cover-github-action/assets/783694/b9f0d0c2-c6a0-4e8f-bbc3-7cf2062b5beb)

- [x] Added check for excessive description length into `Build` workflow
- [x] Shortened `action.yml` description