### PR TITLE
[TG-21107] Automate releases

### DIFF
--- a/.github/release.sh
+++ b/.github/release.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+REPO="diffblue/cover-github-action"
+BRANCH_NAME="release/$1"
+PR_TITLE="Release $1"
+PR_BODY="Update Diffblue Cover to $1"
+
+git checkout -b "$BRANCH_NAME"
+
+sed -i "s/cli:[0-9]\{4\}\.[0-9]\{2\}\.[0-9]\{2\}-jdk/cli:$1-jdk/g" Dockerfile
+
+./build.sh
+git add Dockerfile
+git add */Dockerfile
+git commit -m "Bump docker image to $1"
+
+git push origin "$BRANCH_NAME"
+
+curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
+     -d '{"title": "'"$PR_TITLE"'", "body": "'"$PR_BODY"'", "head": "'"$BRANCH_NAME"'", "base": "main"}' \
+     "https://api.github.com/repos/$REPO/pulls"

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create release
-        if: contains(github.event.head_commit.message, '/Release/')
+        if: contains(github.event.head_commit.message, '/release/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION_NUMBER=$(echo "${{github.event.head_commit.message}}" | sed -n 's/.*Release\/\([0-9]\{4\}\.[0-9]\{2\}\.[0-9]\{2\}\).*/\1/p')
+          VERSION_NUMBER=$(echo "${{github.event.head_commit.message}}" | sed -n 's/.*release\/\([0-9]\{4\}\.[0-9]\{2\}\.[0-9]\{2\}\).*/\1/p')
           if [ -n "$VERSION_NUMBER" ]; then
             gh release create "v$VERSION_NUMBER" --repo="$GITHUB_REPOSITORY" --title="v$VERSION_NUMBER" --generate-notes
           else

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,24 @@
+name: Create release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release
+        if: contains(github.event.head_commit.message, '/Release/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION_NUMBER=$(echo "${{github.event.head_commit.message}}" | sed -n 's/.*Release\/\([0-9]\{4\}\.[0-9]\{2\}\.[0-9]\{2\}\).*/\1/p')
+          if [ -n "$VERSION_NUMBER" ]; then
+            gh release create "v$VERSION_NUMBER" --repo="$GITHUB_REPOSITORY" --title="v$VERSION_NUMBER" --generate-notes
+          else
+            echo "Could not get version number from commit name: ${{github.event.head_commit.message}}"
+            exit 1
+          fi


### PR DESCRIPTION
There is a script to be called during the release process which will create a release PR (I want to keep the logic in this repo). Once this PR is merged then a release will be created.
Here is an example of a PR created with this https://github.com/diffblue/cover-github-action/pull/141.